### PR TITLE
SteamLobbyList, SteamLobbyData and SteamLobbyFilter

### DIFF
--- a/addons/steam_lobby/lib/steam_lobby.gd
+++ b/addons/steam_lobby/lib/steam_lobby.gd
@@ -1,4 +1,3 @@
-@tool
 extends Node
 ## SteamLobby
 ## 
@@ -197,7 +196,6 @@ func _on_lobby_data_local_update() -> void:
 	# Check wether the user trying to perform a local change is the owner.
 	# ? Is this necessary to be in the source, can be user checked too maybe?
 	if Steam.getLobbyOwner(lobby_id) != Steam.getSteamID(): print("SteamLobby: You are not the lobby owner!")
-	print(lobby_data)
 
 	var data: Dictionary = lobby_data.get_data()
 	for key in data:

--- a/addons/steam_lobby/lib/steam_lobby.gd
+++ b/addons/steam_lobby/lib/steam_lobby.gd
@@ -90,6 +90,7 @@ func _on_lobby_created(connected: int, this_lobby_id: int) -> void:
 		# Set lobby data and tell the lobby what type of LobbyData is used.
 		lobby_data = _tmp_lobby_data
 		Steam.setLobbyData(lobby_id, "ld_type", lobby_data.get_script().get_global_name())
+		_on_lobby_data_local_update() # Make sure to trigger a local update after init.
 	
 # -- Lobby Joining -- #
 
@@ -194,7 +195,8 @@ var lobby_data: SteamLobbyData:
 ## Reacts to a local update from the lobby_data field.
 func _on_lobby_data_local_update() -> void:
 	# Check wether the user trying to perform a local change is the owner.
-	if Steam.getLobbyOwner(lobby_id) == Steam.getSteamID(): print("SteamLobby: You are not the lobby owner!")
+	# ? Is this necessary to be in the source, can be user checked too maybe?
+	if Steam.getLobbyOwner(lobby_id) != Steam.getSteamID(): print("SteamLobby: You are not the lobby owner!")
 
 	var data: Dictionary = lobby_data.get_data()
 	for key in data:

--- a/addons/steam_lobby/lib/steam_lobby.gd
+++ b/addons/steam_lobby/lib/steam_lobby.gd
@@ -197,6 +197,7 @@ func _on_lobby_data_local_update() -> void:
 	# Check wether the user trying to perform a local change is the owner.
 	# ? Is this necessary to be in the source, can be user checked too maybe?
 	if Steam.getLobbyOwner(lobby_id) != Steam.getSteamID(): print("SteamLobby: You are not the lobby owner!")
+	print(lobby_data)
 
 	var data: Dictionary = lobby_data.get_data()
 	for key in data:

--- a/addons/steam_lobby/lib/steam_lobby.gd
+++ b/addons/steam_lobby/lib/steam_lobby.gd
@@ -205,7 +205,7 @@ func _on_lobby_data_local_update() -> void:
 
 ## Reacts to an external update from the lobby_data field.
 func _on_lobby_data_external_update() -> void:
-	pass
+	lobby_changed.emit()
 
 ## Triggered when the Steam's LobbyData is changed.
 ## Updates the current SteamLobbyData object in lobby_data.

--- a/addons/steam_lobby/lib/steam_lobby.gd
+++ b/addons/steam_lobby/lib/steam_lobby.gd
@@ -26,9 +26,11 @@ var lobby_id: int = 0:
 		lobby_id = new_lobby_id
 		lobby_changed.emit()
 
-		# If lobby is left intentionally we will delete the file.
+		# If lobby is left intentionally we will delete the file and reset LobbyData.
 		if lobby_id == 0:
 			DirAccess.remove_absolute(_lobby_cache_path)
+			lobby_data = null
+			_tmp_lobby_data = null
 		else:
 			var file: FileAccess = FileAccess.open(_lobby_cache_path, FileAccess.WRITE)
 			assert(file, "SteamLobby: Could not open lobby cache for write.")
@@ -49,6 +51,7 @@ func _ready() -> void:
 	Steam.join_requested.connect(_on_lobby_join_requested)
 	Steam.persona_state_change.connect(_on_persona_change)
 	Steam.lobby_chat_update.connect(_on_lobby_chat_update)
+	Steam.lobby_data_update.connect(_on_lobby_data_steam_update)
 
 	_load_lobby_id_from_cache()
 
@@ -71,15 +74,22 @@ func _load_lobby_id_from_cache() -> void:
 
 ## Will create a lobby based on the lobby type provided.
 ## Types are contained in Steam.LobbyType
-func create_lobby(lobby_type: Steam.LobbyType) -> void:
+func create_lobby(lobby_type: Steam.LobbyType, init_lobby_data: SteamLobbyData) -> void:
 	if lobby_id == 0:
 		Steam.createLobby(lobby_type, max_members)
+
+		# Update the temporary lobby data.
+		_tmp_lobby_data = init_lobby_data
 
 ## Ran when Steam sees that a lobby was created.
 func _on_lobby_created(connected: int, this_lobby_id: int) -> void:
 	if connected == 1:
 		# Set the lobby ID
 		lobby_id = this_lobby_id
+
+		# Set lobby data and tell the lobby what type of LobbyData is used.
+		lobby_data = _tmp_lobby_data
+		Steam.setLobbyData(lobby_id, "ld_type", lobby_data.get_script().get_global_name())
 	
 # -- Lobby Joining -- #
 
@@ -164,4 +174,51 @@ func _get_steam_users() -> void:
 
 # -- LobbyData -- #
 
-# TODO: Implement a robust lobby data system.
+## Holds LobbyData that was passed to the create_lobby function.
+## When confirmation is returned then the lobby_data field is populated with this value.
+var _tmp_lobby_data: SteamLobbyData
+
+## LobbyData associated to the current lobby.
+var lobby_data: SteamLobbyData:
+	set(new_lobby_data):
+		if lobby_data:
+			lobby_data.local_update.disconnect(_on_lobby_data_local_update)
+			lobby_data.external_update.disconnect(_on_lobby_data_external_update)
+		
+		if new_lobby_data:
+			new_lobby_data.local_update.connect(_on_lobby_data_local_update)
+			new_lobby_data.external_update.connect(_on_lobby_data_external_update)
+
+		lobby_data = new_lobby_data
+
+## Reacts to a local update from the lobby_data field.
+func _on_lobby_data_local_update() -> void:
+	# Check wether the user trying to perform a local change is the owner.
+	if Steam.getLobbyOwner(lobby_id) == Steam.getSteamID(): print("SteamLobby: You are not the lobby owner!")
+
+	var data: Dictionary = lobby_data.get_data()
+	for key in data:
+		var value: String = data[key]
+		Steam.setLobbyData(lobby_id, key, value)
+
+## Reacts to an external update from the lobby_data field.
+func _on_lobby_data_external_update() -> void:
+	pass
+
+## Triggered when the Steam's LobbyData is changed.
+## Updates the current SteamLobbyData object in lobby_data.
+func _on_lobby_data_steam_update(success: int, _lobby_id: int, issuer_id: int) -> void:
+	# If there's no lobby data yet we'll instantiate a new one from the ld_type field.
+	if not lobby_data:
+		lobby_data = SteamLobbyDataDB.init_from_stringname(Steam.getLobbyData(lobby_id, "ld_type"))
+		
+	# We need to slightly reformat.
+	var raw_data: Dictionary = Steam.getAllLobbyData(lobby_id)
+	var data: Dictionary = {}
+
+	# This removes the indexes from the dict.
+	for idx in raw_data:
+		var val: Dictionary = raw_data[idx]
+		data[val.key] = val.value
+
+	lobby_data.update(data)

--- a/addons/steam_lobby/lib/steam_lobby.gd
+++ b/addons/steam_lobby/lib/steam_lobby.gd
@@ -21,7 +21,6 @@ var max_members: int = 10
 ## The ID of the lobby entered. If 0 the client is not in a Steam lobby.
 var lobby_id: int = 0:
 	set(new_lobby_id):
-		if lobby_id == new_lobby_id: return # If the new lobby ID is the same, nothing has changed.
 		lobby_id = new_lobby_id
 		lobby_changed.emit()
 
@@ -223,3 +222,9 @@ func _on_lobby_data_steam_update(success: int, _lobby_id: int, issuer_id: int) -
 		data[val.key] = val.value
 
 	lobby_data.update(data)
+
+# -- Utility Functions -- #
+
+## Returns whether the current user is owner of the current lobby or not.
+func is_owner_me() -> bool:
+	return Steam.getLobbyOwner(lobby_id) == Steam.getSteamID()

--- a/addons/steam_lobby/lib/steam_lobby_data.gd
+++ b/addons/steam_lobby/lib/steam_lobby_data.gd
@@ -46,5 +46,6 @@ func change_property(property: StringName, value: Variant) -> bool:
 		set(property, value)
 		local_update.emit()
 		return true
+	# Gracefully lets the user know that this field does not exist. We don't need to panic here because no state change happens.
 	printerr("SteamLobbyData: Field %s does not exist in %s." % [property, get_script().get_global_name()])
 	return false

--- a/addons/steam_lobby/lib/steam_lobby_data.gd
+++ b/addons/steam_lobby/lib/steam_lobby_data.gd
@@ -1,0 +1,47 @@
+@abstract
+extends Resource
+class_name SteamLobbyData
+## Abstract resource representing LobbyData
+##
+## User can extend this class and then use it to store and easily manage lobby data
+## via a custom script instead of separate Steam API functions.
+
+# -- External updates -- #
+
+## Signals the outside that LobbyData was changed from the outside.
+signal external_update()
+
+## Updates the LobbyData based on data it has received.
+## Will only update fields that it knows.
+func update(data: Dictionary) -> void:
+	for property in data:
+		if property in self:
+			self[property] = str_to_var(data[property])
+	external_update.emit()
+
+## Returns a dictionary of every user defined variable
+## mapped to it's value as a string.
+## String values are mandatory for Steam LobbyData.
+func get_data() -> Dictionary:
+	var data: Dictionary = {}
+	var properties := get_property_list()
+
+	for property in properties:
+		# Bitwise and to isolate the single SCRIPT_VARIABLE thing.
+		if property.usage & PROPERTY_USAGE_SCRIPT_VARIABLE:
+			data[property.name] = var_to_str(get(property.name))
+
+	return data
+
+# -- Local update -- #
+
+## Emitted when lobby_data is changed locally.
+signal local_update()
+
+## Override 
+func _set(property: StringName, value: Variant) -> bool:
+	if property in self:
+		self[property] = value
+		local_update.emit()
+		return true
+	return false

--- a/addons/steam_lobby/lib/steam_lobby_data.gd
+++ b/addons/steam_lobby/lib/steam_lobby_data.gd
@@ -16,7 +16,7 @@ signal external_update()
 func update(data: Dictionary) -> void:
 	for property in data:
 		if property in self:
-			self[property] = str_to_var(data[property])
+			set(property, str_to_var(data[property]))
 	external_update.emit()
 
 ## Returns a dictionary of every user defined variable
@@ -38,10 +38,13 @@ func get_data() -> Dictionary:
 ## Emitted when lobby_data is changed locally.
 signal local_update()
 
-## Override 
-func _set(property: StringName, value: Variant) -> bool:
+## Locally updates a property from outside.
+## Using this function to change properties is mandatory if you want others to get the updates.
+## Will let the user know if an attempt to change a non-existing property is done.
+func change_property(property: StringName, value: Variant) -> bool:
 	if property in self:
-		self[property] = value
+		set(property, value)
 		local_update.emit()
 		return true
+	printerr("SteamLobbyData: Field %s does not exist in %s." % [property, get_script().get_global_name()])
 	return false

--- a/addons/steam_lobby/lib/steam_lobby_data.gd.uid
+++ b/addons/steam_lobby/lib/steam_lobby_data.gd.uid
@@ -1,0 +1,1 @@
+uid://id3wsnkrm820

--- a/addons/steam_lobby/lib/steam_lobby_data_db.gd
+++ b/addons/steam_lobby/lib/steam_lobby_data_db.gd
@@ -1,0 +1,20 @@
+extends Node
+
+## Carries all types of user defined SteamLobbyData
+var TYPES_LOBBY_DATA: Dictionary[StringName, GDScript] = {}
+
+func _init() -> void:
+	# Load all custom LinkState classes as scripts that can be instantiated.
+	for cls in ProjectSettings.get_global_class_list():
+		if cls.base == "SteamLobbyData":
+			TYPES_LOBBY_DATA[cls["class"]] = load(cls.path)
+
+# -- Retrieval -- #
+
+## Will return an empty SteamLobbyData resource derived
+## from the given class_name, if it exists.
+func init_from_stringname(stringname: StringName) -> SteamLobbyData:
+	assert(TYPES_LOBBY_DATA.has(stringname), "SteamLobbyDataDB: Class with name %s does not exist." % stringname)
+
+	var lobby_data: SteamLobbyData = TYPES_LOBBY_DATA[stringname].new()
+	return lobby_data

--- a/addons/steam_lobby/lib/steam_lobby_data_db.gd
+++ b/addons/steam_lobby/lib/steam_lobby_data_db.gd
@@ -1,4 +1,7 @@
 extends Node
+## Database for all SteamLobbyData types.
+##
+## Get an instance with init_from_stringname()
 
 ## Carries all types of user defined SteamLobbyData
 var TYPES_LOBBY_DATA: Dictionary[StringName, GDScript] = {}

--- a/addons/steam_lobby/lib/steam_lobby_data_db.gd
+++ b/addons/steam_lobby/lib/steam_lobby_data_db.gd
@@ -1,4 +1,3 @@
-@tool
 extends Node
 ## Database for all SteamLobbyData types.
 ##

--- a/addons/steam_lobby/lib/steam_lobby_data_db.gd
+++ b/addons/steam_lobby/lib/steam_lobby_data_db.gd
@@ -1,3 +1,4 @@
+@tool
 extends Node
 ## Database for all SteamLobbyData types.
 ##

--- a/addons/steam_lobby/lib/steam_lobby_data_db.gd.uid
+++ b/addons/steam_lobby/lib/steam_lobby_data_db.gd.uid
@@ -1,0 +1,1 @@
+uid://ba30qldjcjch0

--- a/addons/steam_lobby/lib/steam_lobby_filter.gd
+++ b/addons/steam_lobby/lib/steam_lobby_filter.gd
@@ -46,7 +46,7 @@ func apply_filters() -> void:
 				var filter: Variant = get(property.name)
 				var filter_type: FILTER_TYPE = get("t_" + base)
 				var comparison: Steam.LobbyComparison = get("c_" + base)
-
+				
 				match filter_type:
 					FILTER_TYPE.STRING:
 						# Because of the way we are storing LobbyData we need to filter on the var_to_str. "\"example\"" with escapes.

--- a/addons/steam_lobby/lib/steam_lobby_filter.gd
+++ b/addons/steam_lobby/lib/steam_lobby_filter.gd
@@ -44,7 +44,9 @@ func apply_filters() -> void:
 
 				# Get all needed variables.
 				var filter: Variant = get(property.name)
+				assert("t_" + base in self, "SteamLobbyFilter: Did not find FILTER_TYPE field for %s. Define it as t_%s with type FILTER_TYPE." % [base, base])
 				var filter_type: FILTER_TYPE = get("t_" + base)
+				assert("c_" + base in self, "SteamLobbyFilter: Did not find Steam.LobbyComparison field for %s. Define it as c_%s with type Steam.LobbyComparison." % [base, base])
 				var comparison: Steam.LobbyComparison = get("c_" + base)
 				
 				match filter_type:

--- a/addons/steam_lobby/lib/steam_lobby_filter.gd
+++ b/addons/steam_lobby/lib/steam_lobby_filter.gd
@@ -23,9 +23,11 @@ enum FILTER_TYPE {
 
 # -- Default Filter parameters -- #
 
+@export_group("Default Parameters")
+
 ## Distance Filter applied to Steam's lobby search.
 ## Default: Steam.LOBBY_DISTANCE_FILTER_DEFAULT
-var distance: Steam.LobbyDistanceFilter = Steam.LOBBY_DISTANCE_FILTER_DEFAULT
+@export var distance: Steam.LobbyDistanceFilter = Steam.LOBBY_DISTANCE_FILTER_DEFAULT
 
 # -- Filter Application -- #
 
@@ -47,7 +49,8 @@ func apply_filters() -> void:
 
 				match filter_type:
 					FILTER_TYPE.STRING:
-						Steam.addRequestLobbyListStringFilter(base, filter, comparison)
+						# Because of the way we are storing LobbyData we need to filter on the var_to_str. "\"example\"" with escapes.
+						Steam.addRequestLobbyListStringFilter(base, var_to_str(filter), comparison)
 					FILTER_TYPE.NUMERICAL:
 						Steam.addRequestLobbyListNumericalFilter(base, filter, comparison)
 					FILTER_TYPE.NEAR_VALUE:

--- a/addons/steam_lobby/lib/steam_lobby_filter.gd
+++ b/addons/steam_lobby/lib/steam_lobby_filter.gd
@@ -1,0 +1,56 @@
+@abstract
+extends Resource
+class_name SteamLobbyFilter
+## Filter resource for filtering lobbies from the SteamLobbyList
+##
+## Holds some parameters that will prompt certain filters onto the Steam backend.
+## Custom LobbyData parameters are user defined.
+## [br]
+## Any user defined filter must use the Filter, Type, Comparison name scheme as follows:
+## f_example, t_example, c_example, respectively holding the actual to filter value, the type and the comparison type.
+## The name of the variable has to line up with the name of the LobbyData.
+
+# -- Filter Types -- #
+
+## Types of filters that can be applied.
+## Includes OFF so the filter can be turned off.
+enum FILTER_TYPE {
+	OFF,
+	STRING,
+	NUMERICAL,
+	NEAR_VALUE
+}
+
+# -- Default Filter parameters -- #
+
+## Distance Filter applied to Steam's lobby search.
+## Default: Steam.LOBBY_DISTANCE_FILTER_DEFAULT
+var distance: Steam.LobbyDistanceFilter = Steam.LOBBY_DISTANCE_FILTER_DEFAULT
+
+# -- Filter Application -- #
+
+## Will apply the filter to Steam's lobby search.
+func apply_filters() -> void:
+	Steam.addRequestLobbyListDistanceFilter(distance)
+	var properties := get_property_list()
+
+	for property in properties:
+		# Bitwise and to isolate the single SCRIPT_VARIABLE thing.
+		if property.usage & PROPERTY_USAGE_SCRIPT_VARIABLE:
+			if property.name.begins_with("f_"):
+				var base: String = property.name.trim_prefix("f_")
+
+				# Get all needed variables.
+				var filter: Variant = get(property.name)
+				var filter_type: FILTER_TYPE = get("t_" + base)
+				var comparison: Steam.LobbyComparison = get("c_" + base)
+
+				match filter_type:
+					FILTER_TYPE.STRING:
+						Steam.addRequestLobbyListStringFilter(base, filter, comparison)
+					FILTER_TYPE.NUMERICAL:
+						Steam.addRequestLobbyListNumericalFilter(base, filter, comparison)
+					FILTER_TYPE.NEAR_VALUE:
+						Steam.addRequestLobbyListNearValueFilter(base, filter)
+					FILTER_TYPE.OFF:
+						pass

--- a/addons/steam_lobby/lib/steam_lobby_filter.gd.uid
+++ b/addons/steam_lobby/lib/steam_lobby_filter.gd.uid
@@ -1,0 +1,1 @@
+uid://ctg8frd0i7o7f

--- a/addons/steam_lobby/lib/steam_lobby_list.gd
+++ b/addons/steam_lobby/lib/steam_lobby_list.gd
@@ -1,0 +1,35 @@
+@tool
+extends Node
+class_name SteamLobbyList
+## Carries and updates a list of Steam lobbies.
+
+# TODO: Implement filters.
+# -- Filters -- #
+
+
+# -- Timer -- #
+
+## Timer that will trigger a lobby list request on timeout.
+var _fetch_timer: Timer
+
+@export var refresh_time: int
+
+func _ready() -> void:
+	Steam.lobby_match_list.connect(_receive_lobby_list)
+
+	_fetch_timer = Timer.new()
+	_fetch_timer.wait_time = refresh_time
+	_fetch_timer.timeout.connect(request_lobbies)
+	_fetch_timer.autostart = true
+
+	add_child(_fetch_timer)
+
+# -- Retrieval lobbies -- #
+
+func request_lobbies() -> void:
+	# TODO: Implement filters here
+
+	Steam.requestLobbyList()
+
+func _receive_lobby_list(lobbies: Array) -> void:
+	print(lobbies)

--- a/addons/steam_lobby/lib/steam_lobby_list.gd
+++ b/addons/steam_lobby/lib/steam_lobby_list.gd
@@ -18,6 +18,15 @@ var lobbies: Array
 
 # -- Timer -- #
 
+## Whether the lobby fetching should be enabled or not.
+var enabled: bool = false:
+	set(n_enabled):
+		enabled = n_enabled
+		if enabled: 
+			request_lobbies()
+			_fetch_timer.start()
+		else: _fetch_timer.stop()
+
 ## Timer that will trigger a lobby list request on timeout.
 var _fetch_timer: Timer
 
@@ -33,7 +42,6 @@ func _ready() -> void:
 	_fetch_timer.autostart = true
 
 	add_child(_fetch_timer)
-	request_lobbies() # Initially request lobbies.
 
 # -- Retrieval lobbies -- #
 

--- a/addons/steam_lobby/lib/steam_lobby_list.gd
+++ b/addons/steam_lobby/lib/steam_lobby_list.gd
@@ -55,3 +55,5 @@ func request_lobbies() -> void:
 func _receive_lobby_list(p_lobbies: Array) -> void:
 	lobbies = p_lobbies
 	lobbies_updated.emit(lobbies)
+
+# TODO: Add Formatting for lobbies.

--- a/addons/steam_lobby/lib/steam_lobby_list.gd
+++ b/addons/steam_lobby/lib/steam_lobby_list.gd
@@ -3,15 +3,25 @@ extends Node
 class_name SteamLobbyList
 ## Carries and updates a list of Steam lobbies.
 
-# TODO: Implement filters.
+# -- Lobbies -- #
+
+## Lets the outside know that lobbies was updated.
+signal lobbies_updated(lobbies: Array)
+
+## List of lobbies, updated at interval refresh_time.
+var lobbies: Array
+
 # -- Filters -- #
 
+## The Filter that is applied every time lobbies are fetched.
+@export var lobby_filter: SteamLobbyFilter
 
 # -- Timer -- #
 
 ## Timer that will trigger a lobby list request on timeout.
 var _fetch_timer: Timer
 
+## The time between every request sent to Steam.
 @export var refresh_time: int
 
 func _ready() -> void:
@@ -23,13 +33,17 @@ func _ready() -> void:
 	_fetch_timer.autostart = true
 
 	add_child(_fetch_timer)
+	request_lobbies() # Initially request lobbies.
 
 # -- Retrieval lobbies -- #
 
+## Applies the SteamLobbyFilter if there is one and then requests the lobbies.
 func request_lobbies() -> void:
-	# TODO: Implement filters here
+	if lobby_filter: lobby_filter.apply_filters()
 
 	Steam.requestLobbyList()
 
-func _receive_lobby_list(lobbies: Array) -> void:
-	print(lobbies)
+## Receives the lobbies from Steam.
+func _receive_lobby_list(p_lobbies: Array) -> void:
+	lobbies = p_lobbies
+	lobbies_updated.emit(lobbies)

--- a/addons/steam_lobby/lib/steam_lobby_list.gd.uid
+++ b/addons/steam_lobby/lib/steam_lobby_list.gd.uid
@@ -1,0 +1,1 @@
+uid://2fqvetndvvs0

--- a/addons/steam_lobby/lib/steam_user.gd
+++ b/addons/steam_lobby/lib/steam_user.gd
@@ -1,4 +1,3 @@
-@tool
 extends Resource
 class_name SteamUser
 ## Represents a Steam user.

--- a/addons/steam_lobby/plugin.gd
+++ b/addons/steam_lobby/plugin.gd
@@ -8,12 +8,13 @@ func _enable_plugin() -> void:
 func _disable_plugin() -> void:
 	remove_autoload_singleton("SteamLobby")
 
-
 func _enter_tree() -> void:
-	# Initialization of the plugin goes here.
-	pass
-
+	add_custom_type(
+		"SteamLobbyList",
+		"Node",
+		preload("lib/steam_lobby_list.gd"),
+		null
+	)
 
 func _exit_tree() -> void:
-	# Clean-up of the plugin goes here.
-	pass
+	remove_custom_type("SteamLobbyList")

--- a/addons/steam_lobby/plugin.gd
+++ b/addons/steam_lobby/plugin.gd
@@ -5,7 +5,6 @@ func _enable_plugin() -> void:
 	add_autoload_singleton("SteamLobby", "res://addons/steam_lobby/lib/steam_lobby.gd")
 	add_autoload_singleton("SteamLobbyDataDB", "res://addons/steam_lobby/lib/steam_lobby_data_db.gd")
 
-
 func _disable_plugin() -> void:
 	remove_autoload_singleton("SteamLobby")
 	remove_autoload_singleton("SteamLobbyDataDB")

--- a/addons/steam_lobby/plugin.gd
+++ b/addons/steam_lobby/plugin.gd
@@ -3,10 +3,12 @@ extends EditorPlugin
 
 func _enable_plugin() -> void:
 	add_autoload_singleton("SteamLobby", "res://addons/steam_lobby/lib/steam_lobby.gd")
+	add_autoload_singleton("SteamLobbyDataDB", "res://addons/steam_lobby/lib/steam_lobby_data_db.gd")
 
 
 func _disable_plugin() -> void:
 	remove_autoload_singleton("SteamLobby")
+	remove_autoload_singleton("SteamLobbyDataDB")
 
 func _enter_tree() -> void:
 	add_custom_type(

--- a/example/example.gd
+++ b/example/example.gd
@@ -10,6 +10,7 @@ func _new_lobby() -> void:
 	if SteamLobby.lobby_id == 0:
 		%JoinCreate.show()
 		%LeaveLobby.hide()
+		%LobbyName.hide()
 		%LobbyID.editable = true
 		%LobbyID.text = "0"
 
@@ -19,6 +20,7 @@ func _new_lobby() -> void:
 		# This is triggered when a new actual lobby is joined.
 		%JoinCreate.hide()
 		%LeaveLobby.show()
+		%LobbyName.show()
 		%LobbyID.editable = false
 		%LobbyID.text = str(SteamLobby.lobby_id)
 		if SteamLobby.lobby_data is ExampleLobbyData:
@@ -46,7 +48,7 @@ func _on_create_lobby_pressed() -> void:
 
 	SteamLobby.create_lobby(Steam.LobbyType.LOBBY_TYPE_PUBLIC, example_data)
 
-func _on_join_lobby_pressed() -> void:
+func _on_join_lobby_pressed() -> void: 
 	SteamLobby.join_lobby(int(%LobbyID.text))
 
 func _on_leave_lobby_pressed() -> void:
@@ -54,4 +56,4 @@ func _on_leave_lobby_pressed() -> void:
 
 func _on_lobby_name_text_submitted(new_text: String) -> void:
 	if SteamLobby.lobby_data is ExampleLobbyData:
-		SteamLobby.lobby_data.lobby_name = new_text
+		SteamLobby.lobby_data.change_property("lobby_name", new_text)

--- a/example/example.gd
+++ b/example/example.gd
@@ -9,8 +9,11 @@ func _ready() -> void:
 func _new_lobby() -> void:
 	if SteamLobby.lobby_id == 0:
 		%JoinCreate.show()
+		%Filters.show()
+		%SteamLobbyList.enabled = true
 		%LeaveLobby.hide()
 		%LobbyName.hide()
+		%GameType.hide()
 		%LobbyID.editable = true
 		%LobbyID.text = "0"
 
@@ -19,12 +22,16 @@ func _new_lobby() -> void:
 	else:
 		# This is triggered when a new actual lobby is joined.
 		%JoinCreate.hide()
+		%Filters.hide()
+		%SteamLobbyList.enabled = false
 		%LeaveLobby.show()
 		%LobbyName.show()
+		%GameType.show()
 		%LobbyID.editable = false
 		%LobbyID.text = str(SteamLobby.lobby_id)
 		if SteamLobby.lobby_data is ExampleLobbyData:
 			%LobbyName.text = str(SteamLobby.lobby_data.lobby_name)
+			%GameType.selected = SteamLobby.lobby_data.game_type
 		
 		# Generate or update the label for each member
 		_clear_labels()
@@ -60,3 +67,17 @@ func _on_lobby_name_text_submitted(new_text: String) -> void:
 
 func _on_steam_lobby_list_lobbies_updated(lobbies: Array) -> void:
 	print(lobbies)
+
+func _on_option_button_item_selected(index: int) -> void:
+	if SteamLobby.lobby_data is ExampleLobbyData:
+		SteamLobby.lobby_data.change_property("game_type", index)
+
+func _on_filter_game_type_item_selected(index: int) -> void:
+	if index == -1: %SteamLobbyList.lobby_filter.t_game_type = SteamLobbyFilter.FILTER_TYPE.OFF
+	else: %SteamLobbyList.lobby_filter.t_game_type = SteamLobbyFilter.FILTER_TYPE.NUMERICAL
+	%SteamLobbyList.lobby_filter.f_game_type = index
+
+func _on_filter_lobby_name_text_submitted(new_text: String) -> void:
+	if new_text.is_empty(): %SteamLobbyList.lobby_filter.t_lobby_name = SteamLobbyFilter.FILTER_TYPE.OFF
+	else: %SteamLobbyList.lobby_filter.t_lobby_name = SteamLobbyFilter.FILTER_TYPE.STRING
+	%SteamLobbyList.lobby_filter.f_lobby_name = new_text

--- a/example/example.gd
+++ b/example/example.gd
@@ -57,3 +57,6 @@ func _on_leave_lobby_pressed() -> void:
 func _on_lobby_name_text_submitted(new_text: String) -> void:
 	if SteamLobby.lobby_data is ExampleLobbyData:
 		SteamLobby.lobby_data.change_property("lobby_name", new_text)
+
+func _on_steam_lobby_list_lobbies_updated(lobbies: Array) -> void:
+	print(lobbies)

--- a/example/example.gd
+++ b/example/example.gd
@@ -21,6 +21,8 @@ func _new_lobby() -> void:
 		%LeaveLobby.show()
 		%LobbyID.editable = false
 		%LobbyID.text = str(SteamLobby.lobby_id)
+		if SteamLobby.lobby_data is ExampleLobbyData:
+			%LobbyName.text = str(SteamLobby.lobby_data.lobby_name)
 		
 		# Generate or update the label for each member
 		_clear_labels()
@@ -49,3 +51,7 @@ func _on_join_lobby_pressed() -> void:
 
 func _on_leave_lobby_pressed() -> void:
 	SteamLobby.leave_lobby()
+
+func _on_lobby_name_text_submitted(new_text: String) -> void:
+	if SteamLobby.lobby_data is ExampleLobbyData:
+		SteamLobby.lobby_data.lobby_name = new_text

--- a/example/example.gd
+++ b/example/example.gd
@@ -1,19 +1,23 @@
 extends Control
+## An example scene demonstrating plugin functionality.
 
+# Dictionary holding SteamID to corresponding member label.
 var member_labels: Dictionary[int, Label] = {}
 
 func _ready() -> void:
 	SteamLobby.lobby_changed.connect(_new_lobby)
 	_new_lobby()
 
+# -- Visual changes -- #
+
+# Reacts to the lobby_changed signal appropriately.
 func _new_lobby() -> void:
 	if SteamLobby.lobby_id == 0:
 		%JoinCreate.show()
 		%Filters.show()
 		%SteamLobbyList.enabled = true
 		%LeaveLobby.hide()
-		%LobbyName.hide()
-		%GameType.hide()
+		%LobbyDetails.hide()
 		%LobbyID.editable = true
 		%LobbyID.text = "0"
 
@@ -25,13 +29,15 @@ func _new_lobby() -> void:
 		%Filters.hide()
 		%SteamLobbyList.enabled = false
 		%LeaveLobby.show()
-		%LobbyName.show()
-		%GameType.show()
+		%LobbyDetails.show()
 		%LobbyID.editable = false
 		%LobbyID.text = str(SteamLobby.lobby_id)
 		if SteamLobby.lobby_data is ExampleLobbyData:
 			%LobbyName.text = str(SteamLobby.lobby_data.lobby_name)
 			%GameType.selected = SteamLobby.lobby_data.game_type
+
+		%LobbyName.editable = SteamLobby.is_owner_me()
+		%GameType.disabled = !SteamLobby.is_owner_me()
 		
 		# Generate or update the label for each member
 		_clear_labels()
@@ -48,6 +54,8 @@ func _clear_labels():
 		label.queue_free()
 	member_labels.clear()
 
+# -- Joining, leaving and creating -- #
+
 func _on_create_lobby_pressed() -> void:
 	var example_data := ExampleLobbyData.new()
 	example_data.lobby_name = "example"
@@ -61,21 +69,27 @@ func _on_join_lobby_pressed() -> void:
 func _on_leave_lobby_pressed() -> void:
 	SteamLobby.leave_lobby()
 
+# -- Changing LobbyData -- #
+
 func _on_lobby_name_text_submitted(new_text: String) -> void:
 	if SteamLobby.lobby_data is ExampleLobbyData:
 		SteamLobby.lobby_data.change_property("lobby_name", new_text)
-
-func _on_steam_lobby_list_lobbies_updated(lobbies: Array) -> void:
-	print(lobbies)
 
 func _on_option_button_item_selected(index: int) -> void:
 	if SteamLobby.lobby_data is ExampleLobbyData:
 		SteamLobby.lobby_data.change_property("game_type", index)
 
+# -- Filtering and lobbies -- #
+
+## Prints all retrieved lobbies.
+func _on_steam_lobby_list_lobbies_updated(lobbies: Array) -> void:
+	print(lobbies)
+
 func _on_filter_game_type_item_selected(index: int) -> void:
-	if index == -1: %SteamLobbyList.lobby_filter.t_game_type = SteamLobbyFilter.FILTER_TYPE.OFF
-	else: %SteamLobbyList.lobby_filter.t_game_type = SteamLobbyFilter.FILTER_TYPE.NUMERICAL
-	%SteamLobbyList.lobby_filter.f_game_type = index
+	if index == 2: %SteamLobbyList.lobby_filter.t_game_type = SteamLobbyFilter.FILTER_TYPE.OFF
+	else: 
+		%SteamLobbyList.lobby_filter.t_game_type = SteamLobbyFilter.FILTER_TYPE.NUMERICAL
+		%SteamLobbyList.lobby_filter.f_game_type = index
 
 func _on_filter_lobby_name_text_submitted(new_text: String) -> void:
 	if new_text.is_empty(): %SteamLobbyList.lobby_filter.t_lobby_name = SteamLobbyFilter.FILTER_TYPE.OFF

--- a/example/example.gd
+++ b/example/example.gd
@@ -38,7 +38,11 @@ func _clear_labels():
 	member_labels.clear()
 
 func _on_create_lobby_pressed() -> void:
-	SteamLobby.create_lobby(Steam.LobbyType.LOBBY_TYPE_PUBLIC)
+	var example_data := ExampleLobbyData.new()
+	example_data.lobby_name = "example"
+	example_data.game_type = ExampleLobbyData.GAME_TYPES.EXAMPLE
+
+	SteamLobby.create_lobby(Steam.LobbyType.LOBBY_TYPE_PUBLIC, example_data)
 
 func _on_join_lobby_pressed() -> void:
 	SteamLobby.join_lobby(int(%LobbyID.text))

--- a/example/example.tscn
+++ b/example/example.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://b6646y088dd61"]
+[gd_scene load_steps=3 format=3 uid="uid://b6646y088dd61"]
 
 [ext_resource type="Script" uid="uid://daevxdcysycq" path="res://example/example.gd" id="1_fdt2r"]
+[ext_resource type="Script" uid="uid://2fqvetndvvs0" path="res://addons/steam_lobby/lib/steam_lobby_list.gd" id="2_pjyox"]
 
 [node name="Example" type="Control"]
 layout_mode = 3
@@ -10,6 +11,11 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_fdt2r")
+
+[node name="SteamLobbyList" type="Node" parent="."]
+script = ExtResource("2_pjyox")
+refresh_time = 5
+metadata/_custom_type_script = "uid://2fqvetndvvs0"
 
 [node name="LobbyIDLeave" type="HBoxContainer" parent="."]
 layout_mode = 1

--- a/example/example.tscn
+++ b/example/example.tscn
@@ -1,6 +1,13 @@
-[gd_scene load_steps=2 format=3 uid="uid://b6646y088dd61"]
+[gd_scene load_steps=5 format=3 uid="uid://b6646y088dd61"]
 
 [ext_resource type="Script" uid="uid://daevxdcysycq" path="res://example/example.gd" id="1_fdt2r"]
+[ext_resource type="Script" uid="uid://2fqvetndvvs0" path="res://addons/steam_lobby/lib/steam_lobby_list.gd" id="2_pjyox"]
+[ext_resource type="Script" uid="uid://egqjef3xltb5" path="res://example/example_lobby_filter.gd" id="3_8clr1"]
+
+[sub_resource type="Resource" id="Resource_7cn0y"]
+script = ExtResource("3_8clr1")
+f_lobby_name = "test"
+metadata/_custom_type_script = "uid://egqjef3xltb5"
 
 [node name="Example" type="Control"]
 layout_mode = 3
@@ -10,6 +17,12 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_fdt2r")
+
+[node name="SteamLobbyList" type="Node" parent="."]
+script = ExtResource("2_pjyox")
+lobby_filter = SubResource("Resource_7cn0y")
+refresh_time = 5
+metadata/_custom_type_script = "uid://2fqvetndvvs0"
 
 [node name="LobbyIDLeave" type="HBoxContainer" parent="."]
 layout_mode = 1
@@ -72,6 +85,7 @@ offset_left = -68.5625
 offset_bottom = 31.0
 grow_horizontal = 0
 
+[connection signal="lobbies_updated" from="SteamLobbyList" to="." method="_on_steam_lobby_list_lobbies_updated"]
 [connection signal="pressed" from="LobbyIDLeave/LeaveLobby" to="." method="_on_leave_lobby_pressed"]
 [connection signal="pressed" from="JoinCreate/JoinLobby" to="." method="_on_join_lobby_pressed"]
 [connection signal="pressed" from="JoinCreate/CreateLobby" to="." method="_on_create_lobby_pressed"]

--- a/example/example.tscn
+++ b/example/example.tscn
@@ -7,6 +7,8 @@
 [sub_resource type="Resource" id="Resource_7cn0y"]
 script = ExtResource("3_8clr1")
 f_lobby_name = "test"
+t_lobby_name = 0
+f_game_type = 1
 metadata/_custom_type_script = "uid://egqjef3xltb5"
 
 [node name="Example" type="Control"]
@@ -19,6 +21,7 @@ grow_vertical = 2
 script = ExtResource("1_fdt2r")
 
 [node name="SteamLobbyList" type="Node" parent="."]
+unique_name_in_owner = true
 script = ExtResource("2_pjyox")
 lobby_filter = SubResource("Resource_7cn0y")
 refresh_time = 5
@@ -85,8 +88,52 @@ offset_left = -68.5625
 offset_bottom = 31.0
 grow_horizontal = 0
 
+[node name="GameType" type="OptionButton" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 1048.0
+offset_top = 41.0
+offset_right = 1146.0
+offset_bottom = 74.0
+item_count = 2
+popup/item_0/text = "Invalid"
+popup/item_0/id = 0
+popup/item_1/text = "Example"
+popup/item_1/id = 1
+
+[node name="Filters" type="VBoxContainer" parent="."]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -178.0
+offset_top = -97.0
+offset_right = -6.0
+offset_bottom = -7.0
+grow_horizontal = 0
+grow_vertical = 0
+alignment = 2
+
+[node name="FilterLobbyName" type="LineEdit" parent="Filters"]
+layout_mode = 2
+placeholder_text = "lobby name filter"
+
+[node name="FilterGameType" type="OptionButton" parent="Filters"]
+layout_mode = 2
+item_count = 2
+popup/item_0/text = "Invalid"
+popup/item_0/id = 0
+popup/item_1/text = "Example"
+popup/item_1/id = 1
+
 [connection signal="lobbies_updated" from="SteamLobbyList" to="." method="_on_steam_lobby_list_lobbies_updated"]
 [connection signal="pressed" from="LobbyIDLeave/LeaveLobby" to="." method="_on_leave_lobby_pressed"]
 [connection signal="pressed" from="JoinCreate/JoinLobby" to="." method="_on_join_lobby_pressed"]
 [connection signal="pressed" from="JoinCreate/CreateLobby" to="." method="_on_create_lobby_pressed"]
 [connection signal="text_submitted" from="LobbyName" to="." method="_on_lobby_name_text_submitted"]
+[connection signal="item_selected" from="GameType" to="." method="_on_option_button_item_selected"]
+[connection signal="text_submitted" from="Filters/FilterLobbyName" to="." method="_on_filter_lobby_name_text_submitted"]
+[connection signal="item_selected" from="Filters/FilterGameType" to="." method="_on_filter_game_type_item_selected"]

--- a/example/example.tscn
+++ b/example/example.tscn
@@ -55,13 +55,24 @@ text = "Create Lobby"
 [node name="MembersList" type="VBoxContainer" parent="."]
 unique_name_in_owner = true
 layout_mode = 1
-anchors_preset = 11
-anchor_left = 1.0
-anchor_right = 1.0
+anchors_preset = 9
 anchor_bottom = 1.0
-grow_horizontal = 0
 grow_vertical = 2
+alignment = 2
+
+[node name="LobbyName" type="LineEdit" parent="."]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.899
+anchor_top = 0.007
+anchor_right = 0.996
+anchor_bottom = 0.007
+offset_left = -68.5625
+offset_bottom = 31.0
+grow_horizontal = 0
 
 [connection signal="pressed" from="LobbyIDLeave/LeaveLobby" to="." method="_on_leave_lobby_pressed"]
 [connection signal="pressed" from="JoinCreate/JoinLobby" to="." method="_on_join_lobby_pressed"]
 [connection signal="pressed" from="JoinCreate/CreateLobby" to="." method="_on_create_lobby_pressed"]
+[connection signal="text_submitted" from="LobbyName" to="." method="_on_lobby_name_text_submitted"]

--- a/example/example.tscn
+++ b/example/example.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://b6646y088dd61"]
+[gd_scene load_steps=2 format=3 uid="uid://b6646y088dd61"]
 
 [ext_resource type="Script" uid="uid://daevxdcysycq" path="res://example/example.gd" id="1_fdt2r"]
-[ext_resource type="Script" uid="uid://2fqvetndvvs0" path="res://addons/steam_lobby/lib/steam_lobby_list.gd" id="2_pjyox"]
 
 [node name="Example" type="Control"]
 layout_mode = 3
@@ -11,11 +10,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_fdt2r")
-
-[node name="SteamLobbyList" type="Node" parent="."]
-script = ExtResource("2_pjyox")
-refresh_time = 5
-metadata/_custom_type_script = "uid://2fqvetndvvs0"
 
 [node name="LobbyIDLeave" type="HBoxContainer" parent="."]
 layout_mode = 1

--- a/example/example.tscn
+++ b/example/example.tscn
@@ -6,9 +6,10 @@
 
 [sub_resource type="Resource" id="Resource_7cn0y"]
 script = ExtResource("3_8clr1")
-f_lobby_name = "test"
+f_lobby_name = ""
 t_lobby_name = 0
 f_game_type = 1
+t_game_type = 0
 metadata/_custom_type_script = "uid://egqjef3xltb5"
 
 [node name="Example" type="Control"]
@@ -76,25 +77,25 @@ anchor_bottom = 1.0
 grow_vertical = 2
 alignment = 2
 
-[node name="LobbyName" type="LineEdit" parent="."]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.899
-anchor_top = 0.007
-anchor_right = 0.996
-anchor_bottom = 0.007
-offset_left = -68.5625
-offset_bottom = 31.0
-grow_horizontal = 0
-
-[node name="GameType" type="OptionButton" parent="."]
+[node name="LobbyDetails" type="VBoxContainer" parent="."]
 unique_name_in_owner = true
 layout_mode = 0
-offset_left = 1048.0
-offset_top = 41.0
-offset_right = 1146.0
-offset_bottom = 74.0
+offset_left = 967.08545
+offset_top = 4.5360003
+offset_right = 1148.0
+offset_bottom = 70.536
+
+[node name="LobbyDataLabel" type="Label" parent="LobbyDetails"]
+layout_mode = 2
+text = "LobbyData:"
+
+[node name="LobbyName" type="LineEdit" parent="LobbyDetails"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="GameType" type="OptionButton" parent="LobbyDetails"]
+unique_name_in_owner = true
+layout_mode = 2
 item_count = 2
 popup/item_0/text = "Invalid"
 popup/item_0/id = 0
@@ -117,23 +118,31 @@ grow_horizontal = 0
 grow_vertical = 0
 alignment = 2
 
+[node name="FiltersLabel" type="Label" parent="Filters"]
+layout_mode = 2
+text = "Filters:"
+
 [node name="FilterLobbyName" type="LineEdit" parent="Filters"]
 layout_mode = 2
 placeholder_text = "lobby name filter"
 
 [node name="FilterGameType" type="OptionButton" parent="Filters"]
 layout_mode = 2
-item_count = 2
+selected = 2
+allow_reselect = true
+item_count = 3
 popup/item_0/text = "Invalid"
 popup/item_0/id = 0
 popup/item_1/text = "Example"
 popup/item_1/id = 1
+popup/item_2/text = "Off"
+popup/item_2/id = 2
 
 [connection signal="lobbies_updated" from="SteamLobbyList" to="." method="_on_steam_lobby_list_lobbies_updated"]
 [connection signal="pressed" from="LobbyIDLeave/LeaveLobby" to="." method="_on_leave_lobby_pressed"]
 [connection signal="pressed" from="JoinCreate/JoinLobby" to="." method="_on_join_lobby_pressed"]
 [connection signal="pressed" from="JoinCreate/CreateLobby" to="." method="_on_create_lobby_pressed"]
-[connection signal="text_submitted" from="LobbyName" to="." method="_on_lobby_name_text_submitted"]
-[connection signal="item_selected" from="GameType" to="." method="_on_option_button_item_selected"]
+[connection signal="text_submitted" from="LobbyDetails/LobbyName" to="." method="_on_lobby_name_text_submitted"]
+[connection signal="item_selected" from="LobbyDetails/GameType" to="." method="_on_option_button_item_selected"]
 [connection signal="text_submitted" from="Filters/FilterLobbyName" to="." method="_on_filter_lobby_name_text_submitted"]
 [connection signal="item_selected" from="Filters/FilterGameType" to="." method="_on_filter_game_type_item_selected"]

--- a/example/example_lobby_data.gd
+++ b/example/example_lobby_data.gd
@@ -1,0 +1,13 @@
+extends SteamLobbyData
+class_name ExampleLobbyData
+## An example of how a user made LobbyData should look like.
+
+## Name of the lobby.
+var lobby_name: String = "invalid"
+
+## The type of game, here just EXAMPLE.
+var game_type: GAME_TYPES
+enum GAME_TYPES {
+	INVALID,
+	EXAMPLE
+}

--- a/example/example_lobby_data.gd
+++ b/example/example_lobby_data.gd
@@ -8,6 +8,6 @@ var lobby_name: String = "invalid"
 ## The type of game, here just EXAMPLE.
 var game_type: GAME_TYPES
 enum GAME_TYPES {
-	INVALID,
+	INVALID, # ! Always set the first enum value to INVALID. Filters behave weirdly with zero values.
 	EXAMPLE
 }

--- a/example/example_lobby_data.gd.uid
+++ b/example/example_lobby_data.gd.uid
@@ -1,0 +1,1 @@
+uid://bwjclcvhv6en1

--- a/example/example_lobby_filter.gd
+++ b/example/example_lobby_filter.gd
@@ -1,0 +1,9 @@
+extends SteamLobbyFilter
+class_name ExampleLobbyFilter
+## Example of a LobbyFilter.
+
+## Lobby Name filter
+@export var f_lobby_name: String = "example"
+@export var t_lobby_name: FILTER_TYPE = FILTER_TYPE.STRING
+@export var c_lobby_name: Steam.LobbyComparison = Steam.LOBBY_COMPARISON_EQUAL
+

--- a/example/example_lobby_filter.gd
+++ b/example/example_lobby_filter.gd
@@ -7,3 +7,7 @@ class_name ExampleLobbyFilter
 @export var t_lobby_name: FILTER_TYPE = FILTER_TYPE.STRING
 @export var c_lobby_name: Steam.LobbyComparison = Steam.LOBBY_COMPARISON_EQUAL
 
+## GameType filter
+@export var f_game_type: ExampleLobbyData.GAME_TYPES
+@export var t_game_type: FILTER_TYPE = FILTER_TYPE.NUMERICAL
+@export var c_game_type: Steam.LobbyComparison = Steam.LOBBY_COMPARISON_EQUAL

--- a/example/example_lobby_filter.gd
+++ b/example/example_lobby_filter.gd
@@ -1,6 +1,10 @@
 extends SteamLobbyFilter
 class_name ExampleLobbyFilter
 ## Example of a LobbyFilter.
+##
+## Pay attention to the naming scheme because it is important.
+## Each individual filter consist out of 3 variables.
+## Variable names have to align with what you're filtering.
 
 ## Lobby Name filter
 @export var f_lobby_name: String = "example"

--- a/example/example_lobby_filter.gd.uid
+++ b/example/example_lobby_filter.gd.uid
@@ -1,0 +1,1 @@
+uid://egqjef3xltb5

--- a/project.godot
+++ b/project.godot
@@ -27,3 +27,5 @@ enabled=PackedStringArray("res://addons/steam_lobby/plugin.cfg")
 [steam]
 
 initialization/app_id=480
+initialization/initialize_on_startup=false
+initialization/embed_callbacks=false

--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 SteamLobby="*res://addons/steam_lobby/lib/steam_lobby.gd"
+SteamLobbyDataDB="*res://addons/steam_lobby/lib/steam_lobby_data_db.gd"
 
 [editor_plugins]
 


### PR DESCRIPTION
# Contents:

This PR adds functionality for retrieving lists of lobbies from Steam, adding user defined filters to those requests and to make all of that work an easy user defined system for managing LobbyData.

All of the added functionality is also available in the example-scene.

- Closes #1 
- Closes #4 